### PR TITLE
fix: sync with regular Jotai `useAtomValue` implementation

### DIFF
--- a/src/useAtomValue.ts
+++ b/src/useAtomValue.ts
@@ -7,6 +7,72 @@ import { useStore } from 'jotai/react';
 
 type Store = ReturnType<typeof useStore>;
 
+const isPromiseLike = (x: unknown): x is PromiseLike<unknown> =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  typeof (x as any)?.then === 'function';
+
+const attachPromiseMeta = <T>(
+  promise: PromiseLike<T> & {
+    status?: 'pending' | 'fulfilled' | 'rejected';
+    value?: T;
+    reason?: unknown;
+  },
+) => {
+  promise.status = 'pending';
+  promise.then(
+    (v) => {
+      promise.status = 'fulfilled';
+      promise.value = v;
+    },
+    (e) => {
+      promise.status = 'rejected';
+      promise.reason = e;
+    },
+  );
+};
+
+const continuablePromiseMap = new WeakMap<
+  PromiseLike<unknown>,
+  Promise<unknown>
+>();
+
+const createContinuablePromise = <T>(promise: PromiseLike<T>) => {
+  let continuablePromise = continuablePromiseMap.get(promise);
+  if (!continuablePromise) {
+    continuablePromise = new Promise<T>((resolve, reject) => {
+      let curr = promise;
+      const onFulfilled = (me: PromiseLike<T>) => (v: T) => {
+        if (curr === me) {
+          resolve(v);
+        }
+      };
+      const onRejected = (me: PromiseLike<T>) => (e: unknown) => {
+        if (curr === me) {
+          reject(e);
+        }
+      };
+      const registerCancelHandler = (p: PromiseLike<T>) => {
+        if ('onCancel' in p && typeof p.onCancel === 'function') {
+          p.onCancel((nextValue: PromiseLike<T> | T) => {
+            if (isPromiseLike(nextValue)) {
+              continuablePromiseMap.set(nextValue, continuablePromise!);
+              curr = nextValue;
+              nextValue.then(onFulfilled(nextValue), onRejected(nextValue));
+              registerCancelHandler(nextValue);
+            } else {
+              resolve(nextValue);
+            }
+          });
+        }
+      };
+      promise.then(onFulfilled(promise), onRejected(promise));
+      registerCancelHandler(promise);
+    });
+    continuablePromiseMap.set(promise, continuablePromise);
+  }
+  return continuablePromise;
+};
+
 type Options = Parameters<typeof useStore>[0] & {
   delay?: number;
 };
@@ -51,6 +117,10 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   useEffect(() => {
     const unsub = store.sub(atom, () => {
       if (typeof delay === 'number') {
+        const value = store.get(atom);
+        if (isPromiseLike(value)) {
+          attachPromiseMeta(createContinuablePromise(value));
+        }
         // delay rerendering to wait a promise possibly to resolve
         setTimeout(rerender, delay);
         return;
@@ -62,5 +132,10 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   }, [store, atom, delay]);
 
   useDebugValue(value);
+  // The use of isPromiseLike is to be consistent with `use` type.
+  // `instanceof Promise` actually works fine in this case.
+  if (isPromiseLike(value)) {
+    return createContinuablePromise(value);
+  }
   return value;
 }


### PR DESCRIPTION
I encountered some weird suspense bug when using this hook with React 19 `use`, where the suspense boundary flicker on value changes.

I noticed the regular [`useAtomValue`](https://github.com/pmndrs/jotai/blob/bc396110530283143adacccafbe50d527d98150f/src/react/useAtomValue.ts) has got several bug fixes. And updating the implementation here to includes those changes fixed the issue I'm facing.